### PR TITLE
Add basic account operations

### DIFF
--- a/app/account/route.js
+++ b/app/account/route.js
@@ -1,0 +1,23 @@
+import Ember from 'ember';
+
+const {
+  Route,
+  inject: { service },
+  get
+} = Ember;
+
+export default Route.extend({
+  accountAdmin: service('hoodie-account-admin'),
+
+  model(params) {
+    return get(this, 'accountAdmin.accounts').find(params.account_id);
+  },
+
+  beforeModel(transition) {
+    let isLoggedIn = get(this, 'accountAdmin').isSignedIn();
+    if (!isLoggedIn) {
+      transition.abort();
+      this.transitionTo('login');
+    }
+  }
+});

--- a/app/account/route.js
+++ b/app/account/route.js
@@ -23,10 +23,12 @@ export default Route.extend({
 
   actions: {
     deleteAccount(account) {
-      get(this, 'accountAdmin.accounts').remove(account.id)
-      .then(() => {
-        this.transitionTo('accounts');
-      });
+      if (confirm(`Are you sure you'd like to delete ${account.username}'s account?`)) {
+        get(this, 'accountAdmin.accounts').remove(account.id)
+        .then(() => {
+          this.transitionTo('accounts');
+        });
+      }
     }
   }
 });

--- a/app/account/route.js
+++ b/app/account/route.js
@@ -19,5 +19,14 @@ export default Route.extend({
       transition.abort();
       this.transitionTo('login');
     }
+  },
+
+  actions: {
+    deleteAccount(account) {
+      get(this, 'accountAdmin.accounts').remove(account.id)
+      .then(() => {
+        this.transitionTo('accounts');
+      });
+    }
   }
 });

--- a/app/account/template.hbs
+++ b/app/account/template.hbs
@@ -1,0 +1,1 @@
+<p>Username: {{model.username}}</p>

--- a/app/account/template.hbs
+++ b/app/account/template.hbs
@@ -1,1 +1,5 @@
 <p>Username: {{model.username}}</p>
+
+<p>
+  <button class="danger" {{action 'deleteAccount' model}}>Delete account</button>
+</p>

--- a/app/account/template.hbs
+++ b/app/account/template.hbs
@@ -1,3 +1,4 @@
+{{link-to '<- Back to account list' 'accounts'}}
 <p>Username: {{model.username}}</p>
 
 <p>

--- a/app/accounts/controller.js
+++ b/app/accounts/controller.js
@@ -14,6 +14,13 @@ export default Controller.extend({
       get(this, 'accountAdmin').signOut().then(() => {
         this.transitionToRoute('login');
       });
+    },
+
+    createUser(user) {
+      get(this, 'accountAdmin.accounts').add(user)
+      .then((user) => {
+        this.transitionToRoute('account', user.id);
+      });
     }
   }
 });

--- a/app/accounts/route.js
+++ b/app/accounts/route.js
@@ -19,5 +19,4 @@ export default Route.extend({
       this.transitionTo('login');
     }
   }
-
 });

--- a/app/accounts/template.hbs
+++ b/app/accounts/template.hbs
@@ -4,6 +4,8 @@
 <p>Here are the accounts:</p>
 <ul>
   {{#each model as |account|}}
-    <li>{{account-details account=account}}</li>
+    {{#link-to 'account' account}}
+      <li>{{account-details account=account}}</li>
+    {{/link-to}}
   {{/each}}
 </ul>

--- a/app/accounts/template.hbs
+++ b/app/accounts/template.hbs
@@ -1,6 +1,8 @@
 <p>Hello, {{accountAdmin.username}}!</p>
 <p><button {{action 'signOut'}}>Sign out</button></p>
 
+{{new-user createUser=(action 'createUser')}}
+
 <p>Here are the accounts:</p>
 <ul>
   {{#each model as |account|}}

--- a/app/components/new-user/template.hbs
+++ b/app/components/new-user/template.hbs
@@ -1,0 +1,11 @@
+<form>
+  <label>
+    New user's name:
+    {{input value=username data-test-selector="new-user-name"}}
+  </label>
+  <label>
+    New user's password:
+    {{input type='password' value=password data-test-selector="new-user-password"}}
+  </label>
+  <button {{action createUser (hash username=username password=password)}} data-test-selector='new-user-submit'>Add user</button>
+</form>

--- a/app/router.js
+++ b/app/router.js
@@ -7,6 +7,7 @@ const Router = Ember.Router.extend({
 
 Router.map(function() {
   this.route('accounts', {path: '/'});
+  this.route('account', {path: '/account/:account_id'});
   this.route('login');
 });
 

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -27,3 +27,12 @@ input {
   color: #c00;
   font-weight: bold;
 }
+
+button.danger {
+  background-color: #FF0000;
+  color: white;
+}
+
+button.danger:active {
+  background-color: #CC0000;
+}

--- a/tests/helpers/data-attribute-bindings.js
+++ b/tests/helpers/data-attribute-bindings.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+Ember.Component.reopen({
+  attributeBindings: ['data-test-selector']
+});

--- a/tests/integration/components/new-user-test.js
+++ b/tests/integration/components/new-user-test.js
@@ -1,0 +1,28 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('new-user', 'Integration | Component | new user', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  assert.expect(1);
+
+  const username = 'user';
+  const password = 'pass';
+
+  this.set('createUser', function(user) {
+    assert.deepEqual(user, {
+      username,
+      password
+    });
+  });
+
+  this.render(hbs`{{new-user createUser=(action createUser)}}`);
+
+  this.$('[data-test-selector="new-user-name"]').val(username);
+  this.$('[data-test-selector="new-user-name"]').trigger('change');
+  this.$('[data-test-selector="new-user-password"]').val(password);
+  this.$('[data-test-selector="new-user-password"]').trigger('change');
+  this.$('[data-test-selector="new-user-submit"]').click();
+});

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -2,5 +2,6 @@ import resolver from './helpers/resolver';
 import {
   setResolver
 } from 'ember-qunit';
+import './helpers/data-attribute-bindings';
 
 setResolver(resolver);


### PR DESCRIPTION
This adds:
- show page for individual accounts
- deleting an account (via the show page)
- adding a new account (via the account list page)
