### PR TITLE
move hapi & ember-truth-helpers to devDependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,9 @@
 sudo: false
 language: node_js
-cache:
-  directories:
-    - node_modules
-    - bower_components
 notifications:
   email: false
 node_js:
-  - 4
-before_install:
-  - npm i -g npm@^2.0.0
+  - 6
 before_script:
   - npm prune
   - bower prune

--- a/package.json
+++ b/package.json
@@ -54,17 +54,15 @@
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.6.0",
     "ember-resolver": "^2.0.3",
+    "ember-truth-helpers": "^1.2.0",
     "express": "^4.13.4",
     "glob": "^7.0.4",
     "greenkeeper-postpublish": "^1.0.0",
+    "hapi": "^16.0.0",
     "hoodie": "^24.0.0",
     "http-proxy-middleware": "^0.17.0",
     "loader.js": "^4.2.2",
     "morgan": "^1.7.0",
     "semantic-release": "^6.2.2"
-  },
-  "dependencies": {
-    "ember-truth-helpers": "^1.2.0",
-    "hapi": "^16.0.0"
   }
 }


### PR DESCRIPTION
this will reduce the file size when installing hoodie, as babel gets installed trough ember-truth-helpers and we don’t need all that to run hoodie